### PR TITLE
FIX: require `pydantic>=1.9.0` instead of `1.9.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     python_requires=">=3.7",
     install_requires=[
-        "pydantic>=1.9.1,<2.0.0",
+        "pydantic>=1.9.0,<2.0.0",
         "typing-extensions>=4.2.0,<5.0.0",
     ],
     extras_require={


### PR DESCRIPTION
Some applications cannot upgrade to `pydantic==1.9.1` due to https://github.com/samuelcolvin/pydantic/issues/4106, and `cachetory` doesn't really need `1.9.1`. Thus, I'm relaxing the requirements.