### PR TITLE
BREAK: make `cachetory.backends.async_.from_url` non-async

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from cachetory.caches.async_ import Cache
 
 cache = Cache[int](
     serializer=serializers.from_url("pickle+zstd://?pickle-protocol=4&compression-level=3"),
-    backend=(await async_backends.from_url("redis://localhost:6379")),
+    backend=async_backends.from_url("redis://localhost:6379"),
 )
 async with cache:
     await cache.set("foo", 42)
@@ -79,9 +79,9 @@ import cachetory.backends.sync
 import cachetory.backends.async_
 
 backend = cachetory.backends.sync.from_url("memory://")
-backend = await cachetory.backends.async_.from_url("dummy://")
+backend = cachetory.backends.async_.from_url("dummy://")
 backend = cachetory.backends.sync.RedisBackend(redis.Redis(...))
-backend = await cachetory.backends.async_.from_url("redis://localhost:6379/1")
+backend = cachetory.backends.async_.from_url("redis://localhost:6379/1")
 ```
 
 ### Instantiating a serializer

--- a/cachetory/backends/async_/__init__.py
+++ b/cachetory/backends/async_/__init__.py
@@ -14,21 +14,21 @@ else:
     _is_redis_available = True
 
 
-async def from_url(url: str) -> AsyncBackend:
+def from_url(url: str) -> AsyncBackend:
     """
     Creates an asynchronous backend from the given URL.
 
     Examples:
-        >>> await from_url("redis://localhost:6379")
+        >>> from_url("redis://localhost:6379")
     """
     parsed_url = urlparse(url)
     scheme = parsed_url.scheme
     if scheme == "memory":
-        return await MemoryBackend.from_url(url)
+        return MemoryBackend.from_url(url)
     if scheme in ("redis", "rediss", "redis+unix"):
         if not _is_redis_available:
             raise ValueError(f"`{scheme}://` requires `cachetory[redis-async]` extra")
-        return await RedisBackend.from_url(url)
+        return RedisBackend.from_url(url)
     if scheme == "dummy":
-        return await DummyBackend.from_url(url)
+        return DummyBackend.from_url(url)
     raise ValueError(f"`{scheme}://` is not supported")

--- a/cachetory/backends/async_/dummy.py
+++ b/cachetory/backends/async_/dummy.py
@@ -13,7 +13,7 @@ class DummyBackend(AsyncBackend[WireT], Generic[WireT]):
     """
 
     @classmethod
-    async def from_url(cls, url: str) -> DummyBackend:
+    def from_url(cls, url: str) -> DummyBackend:
         return DummyBackend()
 
     async def get(self, key: str) -> WireT:  # pragma: no cover

--- a/cachetory/backends/async_/memory.py
+++ b/cachetory/backends/async_/memory.py
@@ -17,7 +17,7 @@ class MemoryBackend(AsyncBackend[WireT], Generic[WireT]):
     __slots__ = ("_inner",)
 
     @classmethod
-    async def from_url(cls, _url: str) -> MemoryBackend:
+    def from_url(cls, _url: str) -> MemoryBackend:
         return MemoryBackend()
 
     def __init__(self):

--- a/cachetory/backends/async_/redis.py
+++ b/cachetory/backends/async_/redis.py
@@ -17,7 +17,7 @@ class RedisBackend(AsyncBackend[bytes]):
     __slots__ = ("_client",)
 
     @classmethod
-    async def from_url(cls, url: str) -> RedisBackend:
+    def from_url(cls, url: str) -> RedisBackend:
         if url.startswith("redis+"):
             url = url[6:]
         return RedisBackend(aioredis.Redis.from_url(url))

--- a/cachetory/interfaces/backends/async_.py
+++ b/cachetory/interfaces/backends/async_.py
@@ -120,7 +120,7 @@ class AsyncBackend(
 
     @classmethod
     @abstractmethod
-    async def from_url(cls, url: str) -> AsyncBackend:  # pragma: no cover
+    def from_url(cls, url: str) -> AsyncBackend:  # pragma: no cover
         """
         Create an asynchronous cache backend from the specified URL.
 

--- a/tests/backends/async_/test_redis.py
+++ b/tests/backends/async_/test_redis.py
@@ -11,7 +11,7 @@ from tests.support import if_redis_enabled
 
 @fixture
 async def backend() -> AsyncIterable[RedisBackend]:
-    async with await RedisBackend.from_url("redis://localhost:6379") as backend:
+    async with RedisBackend.from_url("redis://localhost:6379") as backend:
         await backend.clear()
         try:
             yield backend

--- a/tests/caches/test_async.py
+++ b/tests/caches/test_async.py
@@ -10,7 +10,7 @@ from tests.support import if_redis_enabled
 async def memory_cache() -> Cache[int]:
     return Cache(
         serializer=serializers.from_url("pickle+zstd://"),
-        backend=(await async_backends.from_url("memory://")),
+        backend=async_backends.from_url("memory://"),
     )
 
 
@@ -50,7 +50,7 @@ async def test_delete(memory_cache: Cache[int]):
 async def test_serialize_executor():
     cache = Cache(
         serializer=serializers.from_url("pickle://"),
-        backend=(await async_backends.from_url("memory://")),
+        backend=async_backends.from_url("memory://"),
         serialize_executor=None,  # that's the default executor, NOT «no executor»
     )
     await cache.set("foo", 42)
@@ -62,7 +62,7 @@ async def test_serialize_executor():
 async def test_get_set_in_redis():
     cache = Cache[int](
         serializer=serializers.from_url("pickle+zlib://"),
-        backend=(await async_backends.from_url("redis://localhost:6379")),
+        backend=async_backends.from_url("redis://localhost:6379"),
     )
     async with cache:
         await cache.set("foo", 42)


### PR DESCRIPTION
Being `async`, `from_url` is inconvenient to use when initializing a cache instance. It also proved to be unnecessary, except for maybe a few corner cases.