### PR TITLE
NEW: use hashed keys by default in the `@cached` decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ def expensive_function() -> int:
     return 42
 ```
 
+There's a few `make_key` functions provided by default:
+
+- `cachetory.decorators.shared.make_default_key` builds a human-readable cache key out of decorated function fully-qualified name and stringified arguments. The length of the key depends on the argument values.
+- `cachetory.decorators.shared.make_default_hashed_key` calls `make_default_key` under the hood but hashes the key and returns a hash hex digest – making it a fixed-length key and not human-readable.
+
 ## Supported backends
 
 The badges indicate which schemes are supported by a particular backend, and which package extras are required for it – if any:

--- a/cachetory/decorators/shared.py
+++ b/cachetory/decorators/shared.py
@@ -1,3 +1,4 @@
+from hashlib import blake2s
 from typing import Any, Callable
 
 
@@ -15,3 +16,12 @@ def make_default_key(callable_: Callable[..., Any], *args: Any, **kwargs: Any) -
         *(f"{str(key).replace(':', '::')}={str(value).replace(':', '::')}" for key, value in sorted(kwargs.items())),
     )
     return ":".join(parts)
+
+
+def make_default_hashed_key(callable_: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
+    """
+    Generates a hashed cache key given the callable and the arguments it's being called with.
+
+    Uses ``blake2s`` as the fastest algorithm from ``hashlib``.
+    """
+    return blake2s(make_default_key(callable_, *args, **kwargs).encode()).hexdigest()

--- a/tests/decorators/test_shared.py
+++ b/tests/decorators/test_shared.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, Tuple
 
 from pytest import mark
 
-from cachetory.decorators.shared import make_default_key
+from cachetory.decorators.shared import make_default_hashed_key, make_default_key
 
 
 def _callable():
@@ -39,3 +39,14 @@ def test_make_default_key(
     expected_key: str,
 ):
     assert make_default_key(callable_, *args, **kwargs) == expected_key
+
+
+def test_make_default_hashed_key():
+    """
+    ``make_default_hashed_key`` calls ``make_default_key`` under the hood,
+    thus one smoke test is enough.
+    """
+    assert (
+        make_default_hashed_key(_callable, "a:b", foo="bar")
+        == "dc3305eaf5bc29bc29d70c3dbf7676c49bfd552cfbec17106fdf71cc01d176c9"
+    )


### PR DESCRIPTION
`make_default_key` returns a key of variable length which depends on stringified representation of the arguments. That may be undesirable, and it wouldn't hurt to hash the representation by default.