### PR TITLE
BREAK: switch from `aioredis` to `redis-py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ The badges indicate which schemes are supported by a particular backend, and whi
 ![scheme: redis](https://img.shields.io/badge/scheme-redis://-important)
 ![scheme: rediss](https://img.shields.io/badge/scheme-rediss://-important)
 ![scheme: redis+unix](https://img.shields.io/badge/scheme-redis+unix://-important)
-![extra: redis-sync](https://img.shields.io/badge/sync-redis--sync-blue)
-![extra: redis-async](https://img.shields.io/badge/async-redis--async-blueviolet)
-![extra: hiredis-async](https://img.shields.io/badge/async-hiredis--async-blueviolet)
+![extra: redis](https://img.shields.io/badge/extra-redis-blue)
 
 | Sync                                   | Async                                    |
 |:---------------------------------------|:-----------------------------------------|
@@ -159,7 +157,7 @@ The URL is forwarded to the underlying client, which means one can use whatever 
 
 All the cache operations are **atomic** in both sync and async, including `get_many` and `set_many`.
 
-`hiredis-async` extra uses `aioredis` with [`hiredis`](https://github.com/redis/hiredis) parser.
+Consider explicitly adding [`hiredis`](https://github.com/redis/hiredis) to your dependencies for faster performance.
 
 ### Memory
 

--- a/cachetory/backends/async_/redis.py
+++ b/cachetory/backends/async_/redis.py
@@ -4,14 +4,14 @@ import itertools
 from datetime import datetime, timedelta
 from typing import AsyncIterable, Iterable, Optional, Tuple
 
-import aioredis
+from redis.asyncio import Redis
 
 from cachetory.interfaces.backends.async_ import AsyncBackend
 
 
 class RedisBackend(AsyncBackend[bytes]):
     """
-    Asynchronous Redis (`aioredis`) backend.
+    Asynchronous Redis backend.
     """
 
     __slots__ = ("_client",)
@@ -20,9 +20,9 @@ class RedisBackend(AsyncBackend[bytes]):
     def from_url(cls, url: str) -> RedisBackend:
         if url.startswith("redis+"):
             url = url[6:]
-        return RedisBackend(aioredis.Redis.from_url(url))
+        return RedisBackend(Redis.from_url(url))
 
-    def __init__(self, client: aioredis.Redis):
+    def __init__(self, client: Redis):
         self._client = client
 
     async def get(self, key: str) -> bytes:

--- a/cachetory/backends/sync/redis.py
+++ b/cachetory/backends/sync/redis.py
@@ -4,23 +4,23 @@ import itertools
 from datetime import datetime, timedelta
 from typing import Iterable, Optional, Tuple
 
-import redis
+from redis import Redis
 
 from cachetory.interfaces.backends.sync import SyncBackend
 
 
 class RedisBackend(SyncBackend[bytes]):
     """
-    Synchronous Redis (`redis-py`) backend.
+    Synchronous Redis backend.
     """
 
     @classmethod
     def from_url(cls, url: str) -> RedisBackend:
         if url.startswith("redis+"):
             url = url[6:]
-        return cls(redis.Redis.from_url(url))
+        return cls(Redis.from_url(url))
 
-    def __init__(self, client: redis.Redis):
+    def __init__(self, client: Redis):
         self._client = client
 
     def get(self, key: str) -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Package in develop mode
--e .[redis-sync,hiredis-async,zstd]
+-e .[redis,zstd]
 
 # Distribution
 twine

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,7 @@ setup(
         "typing-extensions>=4.2.0,<5.0.0",
     ],
     extras_require={
-        "hiredis-async": ["aioredis[hiredis]>=2.0.1,<3.0.0"],
-        "redis-async": ["aioredis>=2.0.1,<3.0.0"],
-        "redis-sync": ["redis>=4.3.3,<5.0.0"],
+        "redis": ["redis>=4.3.0,<5.0.0"],
         "zstd": ["zstd>=1.5.2.5,<2.0.0.0"],
     },
     tests_require=["tox"],


### PR DESCRIPTION
`aioredis` is now included into `redis-py` and not maintained as a separate package.