### PR TITLE
FIX: remove `+zstd` from the quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from cachetory.caches.async_ import Cache
 
 
 cache = Cache[int, bytes](
-    serializer=serializers.from_url("pickle+zstd://?pickle-protocol=4&compression-level=3"),
+    serializer=serializers.from_url("pickle://?pickle-protocol=4"),
     backend=async_backends.from_url("redis://localhost:6379"),
 )
 async with cache:
@@ -31,7 +31,7 @@ from cachetory.caches.sync import Cache
 
 
 cache = Cache[int, bytes](
-    serializer=serializers.from_url("pickle+zstd://"),
+    serializer=serializers.from_url("pickle://"),
     backend=sync_backends.from_url("redis://localhost:6379"),
 )
 with cache:


### PR DESCRIPTION
Zstandard is available via the optional extra, having it in the quickstart confuses some people.