### PR TITLE
OPT: Re-export serializers

### DIFF
--- a/cachetory/serializers/__init__.py
+++ b/cachetory/serializers/__init__.py
@@ -1,9 +1,9 @@
 from cachetory.interfaces.backends.private import WireT
 from cachetory.interfaces.serializers import Serializer, ValueT
 
-from .chained import ChainedSerializer
-from .noop import NoopSerializer  # noqa
-from .pickle import PickleSerializer  # noqa
+from .chained import ChainedSerializer as ChainedSerializer
+from .noop import NoopSerializer as NoopSerializer
+from .pickle import PickleSerializer as PickleSerializer
 
 
 def from_url(url: str) -> Serializer[ValueT, WireT]:


### PR DESCRIPTION
if you don't do this, you get `mypy --strict` errors in applications that import these serializers like so: `from cachetory.serializers import PickleSerializer`.

See for example this FastAPI PR https://github.com/tiangolo/fastapi/pull/2547/files#diff-5de95860eb3dde7b4b64ae5f9710e6ddbfd35a5c9350fb8300198e8784d776e4R7