### PR TITLE
FIX: disable `fail_ci_if_error` for Codecov

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,7 +92,7 @@ jobs:
         env_vars: PYTHON
         name: Python ${{ matrix.python-version }}
         files: coverage.xml
-        fail_ci_if_error: true
+        fail_ci_if_error: false
 
     - name: "📦 Build and publish package: dry run"
       if: success() || failure()


### PR DESCRIPTION
There's the known issue which causes intermittent errors: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954