### PR TITLE
NEW: implement purging specific values set by `@cached`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,8 +26,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
-        - 'pypy-3.8'
-        - 'pypy-3.9'
+        - 'pypy-3.10'
 
     services:
       redis:

--- a/README.md
+++ b/README.md
@@ -141,14 +141,25 @@ another_cache = Cache[int, ...](backend=..., serializer=...)
     time_to_live=None,  # forwarded to `Cache.set`
     if_not_exists=False,  # forwarded to `Cache.set`
 )
-def expensive_function() -> int:
-    return 42
+def expensive_function(x: int) -> int:
+    return 42 * x
 ```
 
-There's a few `make_key` functions provided by default:
+##### Key functions
+
+There are a few `make_key` functions provided by default:
 
 - `cachetory.decorators.shared.make_default_key` builds a human-readable cache key out of decorated function fully-qualified name and stringified arguments. The length of the key depends on the argument values.
 - `cachetory.decorators.shared.make_default_hashed_key` calls `make_default_key` under the hood but hashes the key and returns a hash hex digest – making it a fixed-length key and not human-readable.
+
+##### Purge cache
+
+Specific cached value can be deleted using the added `purge()` function, which accepts the same arguments as the original wrapped callable:
+
+```python
+expensive_function(100500)
+expensive_function.purge(100500)  # purge cached value for this argument
+```
 
 ## Supported backends
 

--- a/cachetory/backends/async_/dummy.py
+++ b/cachetory/backends/async_/dummy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import AsyncIterable, Generic, Iterable, Optional, Tuple
+from typing import AsyncIterable, Generic, Iterable
 
 from cachetory.interfaces.backends.async_ import AsyncBackend
 from cachetory.interfaces.backends.private import WireT
@@ -17,14 +17,14 @@ class DummyBackend(AsyncBackend[WireT], Generic[WireT]):
     async def get(self, key: str) -> WireT:  # pragma: no cover
         raise KeyError(key)
 
-    async def get_many(self, *keys: str) -> AsyncIterable[Tuple[str, WireT]]:
+    async def get_many(self, *keys: str) -> AsyncIterable[tuple[str, WireT]]:
         for _ in ():  # pragma: no cover
             yield ()  # type: ignore
 
-    async def expire_in(self, key: str, time_to_live: Optional[timedelta] = None) -> None:  # pragma: no cover
+    async def expire_in(self, key: str, time_to_live: timedelta | None = None) -> None:  # pragma: no cover
         return None
 
-    async def expire_at(self, key: str, deadline: Optional[datetime]) -> None:  # pragma: no cover
+    async def expire_at(self, key: str, deadline: datetime | None) -> None:  # pragma: no cover
         return None
 
     async def set(  # noqa: A003
@@ -32,12 +32,12 @@ class DummyBackend(AsyncBackend[WireT], Generic[WireT]):
         key: str,
         value: WireT,
         *,
-        time_to_live: Optional[timedelta] = None,
+        time_to_live: timedelta | None = None,
         if_not_exists: bool = False,
     ) -> bool:  # pragma: no cover
         return True
 
-    async def set_many(self, items: Iterable[Tuple[str, WireT]]) -> None:  # pragma: no cover
+    async def set_many(self, items: Iterable[tuple[str, WireT]]) -> None:  # pragma: no cover
         return None
 
     async def delete(self, key: str) -> bool:  # pragma: no cover

--- a/cachetory/backends/async_/memory.py
+++ b/cachetory/backends/async_/memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, Coroutine, Generic, Optional
+from typing import Any, Coroutine, Generic
 
 from cachetory.backends.sync.memory import MemoryBackend as SyncMemoryBackend
 from cachetory.interfaces.backends.async_ import AsyncBackend
@@ -25,7 +25,7 @@ class MemoryBackend(AsyncBackend[WireT], Generic[WireT]):
     def get(self, key: str) -> Coroutine[Any, Any, WireT]:
         return postpone(self._inner.get, key)
 
-    def expire_at(self, key: str, deadline: Optional[datetime]) -> Coroutine[Any, Any, None]:
+    def expire_at(self, key: str, deadline: datetime | None) -> Coroutine[Any, Any, None]:
         return postpone(self._inner.expire_at, key, deadline)
 
     def set(  # noqa: A003
@@ -33,7 +33,7 @@ class MemoryBackend(AsyncBackend[WireT], Generic[WireT]):
         key: str,
         value: WireT,
         *,
-        time_to_live: Optional[timedelta] = None,
+        time_to_live: timedelta | None = None,
         if_not_exists: bool = False,
     ) -> Coroutine[Any, Any, bool]:
         return postpone(

--- a/cachetory/backends/sync/dummy.py
+++ b/cachetory/backends/sync/dummy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Generic, Iterable, Optional, Tuple
+from typing import Generic, Iterable
 
 from cachetory.interfaces.backends.private import WireT
 from cachetory.interfaces.backends.sync import SyncBackend
@@ -17,13 +17,13 @@ class DummyBackend(SyncBackend[WireT], Generic[WireT]):
     def get(self, key: str) -> WireT:  # pragma: no cover
         raise KeyError(key)
 
-    def get_many(self, *keys: str) -> Iterable[Tuple[str, WireT]]:  # pragma: no cover
+    def get_many(self, *keys: str) -> Iterable[tuple[str, WireT]]:  # pragma: no cover
         return []
 
-    def expire_in(self, key: str, time_to_live: Optional[timedelta] = None) -> None:  # pragma: no cover
+    def expire_in(self, key: str, time_to_live: timedelta | None = None) -> None:  # pragma: no cover
         return None
 
-    def expire_at(self, key: str, deadline: Optional[datetime]) -> None:  # pragma: no cover
+    def expire_at(self, key: str, deadline: datetime | None) -> None:  # pragma: no cover
         return None
 
     def set(  # noqa: A003
@@ -31,12 +31,12 @@ class DummyBackend(SyncBackend[WireT], Generic[WireT]):
         key: str,
         value: WireT,
         *,
-        time_to_live: Optional[timedelta] = None,
+        time_to_live: timedelta | None = None,
         if_not_exists: bool = False,
     ) -> bool:  # pragma: no cover
         return True
 
-    def set_many(self, items: Iterable[Tuple[str, WireT]]) -> None:  # pragma: no cover
+    def set_many(self, items: Iterable[tuple[str, WireT]]) -> None:  # pragma: no cover
         return None
 
     def delete(self, key: str) -> bool:  # pragma: no cover

--- a/cachetory/backends/sync/memory.py
+++ b/cachetory/backends/sync/memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Generic, Optional
+from typing import Generic
 
 from cachetory.interfaces.backends.private import WireT
 from cachetory.interfaces.backends.sync import SyncBackend
@@ -18,12 +18,12 @@ class MemoryBackend(SyncBackend[WireT], Generic[WireT]):
         return MemoryBackend()
 
     def __init__(self) -> None:
-        self._entries: Dict[str, _Entry[WireT]] = {}
+        self._entries: dict[str, _Entry[WireT]] = {}
 
     def get(self, key: str) -> WireT:
         return self._get_entry(key).value
 
-    def expire_at(self, key: str, deadline: Optional[datetime]) -> None:
+    def expire_at(self, key: str, deadline: datetime | None) -> None:
         try:
             entry = self._get_entry(key)
         except KeyError:
@@ -36,7 +36,7 @@ class MemoryBackend(SyncBackend[WireT], Generic[WireT]):
         key: str,
         value: WireT,
         *,
-        time_to_live: Optional[timedelta] = None,
+        time_to_live: timedelta | None = None,
         if_not_exists: bool = False,
     ) -> bool:
         entry = _Entry[WireT](value, make_deadline(time_to_live))
@@ -68,11 +68,11 @@ class _Entry(Generic[WireT]):
     """`mypy` doesn't support generic named tuples, thus defining this little one."""
 
     value: WireT
-    deadline: Optional[datetime]
+    deadline: datetime | None
 
     __slots__ = ("value", "deadline")
 
-    def __init__(self, value: WireT, deadline: Optional[datetime]) -> None:
+    def __init__(self, value: WireT, deadline: datetime | None) -> None:
         self.value = value
         self.deadline = deadline
 

--- a/cachetory/interfaces/backends/async_.py
+++ b/cachetory/interfaces/backends/async_.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timedelta, timezone
-from typing import AsyncIterable, Generic, Iterable, Optional, Tuple
+from typing import AsyncIterable, Generic, Iterable
 
 from typing_extensions import Protocol
 
@@ -32,7 +32,7 @@ class AsyncBackendRead(Protocol[WireT_co]):
         """
         raise NotImplementedError
 
-    async def get_many(self, *keys: str) -> AsyncIterable[Tuple[str, WireT_co]]:
+    async def get_many(self, *keys: str) -> AsyncIterable[tuple[str, WireT_co]]:
         """
         Get all the values corresponding to the specified keys.
 
@@ -51,12 +51,12 @@ class AsyncBackendRead(Protocol[WireT_co]):
 class AsyncBackendWrite(Protocol[WireT_contra]):
     """Describes the write operations of an asynchronous cache."""
 
-    async def expire_in(self, key: str, time_to_live: Optional[timedelta] = None) -> None:
+    async def expire_in(self, key: str, time_to_live: timedelta | None = None) -> None:
         """Set the expiration time on the key."""
         deadline = datetime.now(timezone.utc) + time_to_live if time_to_live is not None else None
         await self.expire_at(key, deadline)
 
-    async def expire_at(self, key: str, deadline: Optional[datetime]) -> None:  # pragma: no cover
+    async def expire_at(self, key: str, deadline: datetime | None) -> None:  # pragma: no cover
         """Set the expiration deadline on the key."""
         raise NotImplementedError
 
@@ -65,7 +65,7 @@ class AsyncBackendWrite(Protocol[WireT_contra]):
         key: str,
         value: WireT_contra,
         *,
-        time_to_live: Optional[timedelta] = None,
+        time_to_live: timedelta | None = None,
         if_not_exists: bool = False,
     ) -> bool:  # pragma: no cover
         """
@@ -77,7 +77,7 @@ class AsyncBackendWrite(Protocol[WireT_contra]):
         """
         raise NotImplementedError
 
-    async def set_many(self, items: Iterable[Tuple[str, WireT_contra]]) -> None:
+    async def set_many(self, items: Iterable[tuple[str, WireT_contra]]) -> None:
         """Put all the specified values to the cache."""
         for key, value in items:
             await self.set(key, value)

--- a/cachetory/interfaces/backends/sync.py
+++ b/cachetory/interfaces/backends/sync.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from contextlib import AbstractContextManager
 from datetime import datetime, timedelta
-from typing import Generic, Iterable, Optional, Tuple
+from typing import Generic, Iterable
 
 from typing_extensions import Protocol
 
@@ -33,7 +33,7 @@ class SyncBackendRead(Protocol[WireT_co]):
         """
         raise NotImplementedError
 
-    def get_many(self, *keys: str) -> Iterable[Tuple[str, WireT_co]]:
+    def get_many(self, *keys: str) -> Iterable[tuple[str, WireT_co]]:
         """
         Get all the values corresponding to the specified keys.
 
@@ -52,11 +52,11 @@ class SyncBackendRead(Protocol[WireT_co]):
 class SyncBackendWrite(Protocol[WireT_contra]):
     """Describes the write operations of a synchronous cache."""
 
-    def expire_in(self, key: str, time_to_live: Optional[timedelta] = None) -> None:
+    def expire_in(self, key: str, time_to_live: timedelta | None = None) -> None:
         """Set the expiration time on the key."""
         self.expire_at(key, make_deadline(time_to_live))
 
-    def expire_at(self, key: str, deadline: Optional[datetime]) -> None:  # pragma: no cover
+    def expire_at(self, key: str, deadline: datetime | None) -> None:  # pragma: no cover
         """Set the expiration deadline on the key."""
         raise NotImplementedError
 
@@ -65,7 +65,7 @@ class SyncBackendWrite(Protocol[WireT_contra]):
         key: str,
         value: WireT_contra,
         *,
-        time_to_live: Optional[timedelta] = None,
+        time_to_live: timedelta | None = None,
         if_not_exists: bool = False,
     ) -> bool:  # pragma: no cover
         """
@@ -77,7 +77,7 @@ class SyncBackendWrite(Protocol[WireT_contra]):
         """
         raise NotImplementedError
 
-    def set_many(self, items: Iterable[Tuple[str, WireT_contra]]) -> None:
+    def set_many(self, items: Iterable[tuple[str, WireT_contra]]) -> None:
         """Put all the specified values to the cache."""
         for key, value in items:
             self.set(key, value)

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,9 +11,6 @@ files = [
     {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=3.6.5", markers = "python_version < \"3.8\""}
-
 [[package]]
 name = "black"
 version = "23.3.0"
@@ -55,7 +52,6 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -153,7 +149,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -311,26 +306,6 @@ files = [
 python-dateutil = ">=2.7"
 
 [[package]]
-name = "importlib-metadata"
-version = "6.7.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
-    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -379,7 +354,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -462,9 +436,6 @@ files = [
     {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.6.3", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
@@ -479,9 +450,6 @@ files = [
     {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
     {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -564,7 +532,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -586,7 +553,6 @@ files = [
 
 [package.dependencies]
 pytest = ">=6.1.0"
-typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
@@ -637,8 +603,6 @@ files = [
 
 [package.dependencies]
 async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
-importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
@@ -693,56 +657,6 @@ files = [
 ]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.5"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bc1efe0ce3ffb74784e06460f01a223ac1f6ab31c6bc0376a21184bf5aabe3b"},
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f7a8c46a8b333f71abd61d7ab9255440d4a588f34a21f126bbfc95f6049e686"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:597fc66b4162f959ee6a96b978c0435bd63791e31e4f410622d19f1686d5e769"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d41b7a686ce653e06c2609075d397ebd5b969d821b9797d029fccd71fdec8e04"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5fe83a9a44c4ce67c796a1b466c270c1272e176603d5e06f6afbc101a572859d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d5c0c112a74c0e5db2c75882a0adf3133adedcdbfd8cf7c9d6ed77365ab90a1d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:e1a976ed4cc2d71bb073e1b2a250892a6e968ff02aa14c1f40eba4f365ffec02"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c631da9710271cb67b08bd3f3813b7af7f4c69c319b75475436fcab8c3d21bee"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b445c2abfecab89a932b20bd8261488d574591173d07827c1eda32c457358b18"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc95ffaaab2be3b25eb938779e43f513e0e538a84dd14a5d844b8f2932593d88"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61443214d9b4c660dcf4b5307f15c12cb30bdfe9588ce6158f4a005baeb167b2"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6eb936d107e4d474940469e8ec5b380c9b329b5f08b78282d46baeebd3692dc9"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e48bf27022897577d8479eaed64701ecaf0467182448bd95759883300ca818c8"},
-    {file = "typed_ast-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:83509f9324011c9a39faaef0922c6f720f9623afe3fe220b6d0b15638247206b"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f214394fc1af23ca6d4e9e744804d890045d1643dd7e8229951e0ef39429b5"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118c1ce46ce58fda78503eae14b7664163aa735b620b64b5b725453696f2a35c"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4919b808efa61101456e87f2d4c75b228f4e52618621c77f1ddcaae15904fa"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:fc2b8c4e1bc5cd96c1a823a885e6b158f8451cf6f5530e1829390b4d27d0807f"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:16f7313e0a08c7de57f2998c85e2a69a642e97cb32f87eb65fbfe88381a5e44d"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:2b946ef8c04f77230489f75b4b5a4a6f24c078be4aed241cfabe9cbf4156e7e5"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2188bc33d85951ea4ddad55d2b35598b2709d122c11c75cffd529fbc9965508e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0635900d16ae133cab3b26c607586131269f88266954eb04ec31535c9a12ef1e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57bfc3cf35a0f2fdf0a88a3044aafaec1d2f24d8ae8cd87c4f58d615fb5b6311"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d09d930c2d1d621f717bb217bf1fe2584616febb5138d9b3e8cdd26506c3f6d4"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:d40c10326893ecab8a80a53039164a224984339b2c32a6baf55ecbd5b1df6431"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fd946abf3c31fb50eee07451a6aedbfff912fcd13cf357363f5b4e834cc5e71a"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ed4a1a42df8a3dfb6b40c3d2de109e935949f2f66b19703eafade03173f8f437"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:045f9930a1550d9352464e5149710d56a2aed23a2ffe78946478f7b5416f1ede"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:381eed9c95484ceef5ced626355fdc0765ab51d8553fec08661dce654a935db4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bfd39a41c0ef6f31684daff53befddae608f9daf6957140228a08e51f312d7e6"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8c524eb3024edcc04e288db9541fe1f438f82d281e591c548903d5b77ad1ddd4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-win_amd64.whl", hash = "sha256:7f58fabdde8dcbe764cef5e1a7fcb440f2463c1bbbec1cf2a86ca7bc1f95184b"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:622e4a006472b05cf6ef7f9f2636edc51bda670b7bbffa18d26b255269d3d814"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1efebbbf4604ad1283e963e8915daa240cb4bf5067053cf2f0baadc4d4fb51b8"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0aefdd66f1784c58f65b502b6cf8b121544680456d1cebbd300c2c813899274"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:48074261a842acf825af1968cd912f6f21357316080ebaca5f19abbb11690c8a"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:429ae404f69dc94b9361bb62291885894b7c6fb4640d561179548c849f8492ba"},
-    {file = "typed_ast-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155"},
-    {file = "typed_ast-1.5.5.tar.gz", hash = "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd"},
-]
-
-[[package]]
 name = "types-pyopenssl"
 version = "23.2.0.1"
 description = "Typing stubs for pyOpenSSL"
@@ -781,21 +695,6 @@ files = [
     {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
     {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
-
-[[package]]
-name = "zipp"
-version = "3.15.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "zstd"
@@ -900,5 +799,5 @@ zstd = ["zstd"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7.0"
-content-hash = "c18b0216d43af1763d72d234db56fa2dc942874e2011dc7e4fcdf5adbbfff1f7"
+python-versions = "^3.8.0"
+content-hash = "5da48d920e9398c9a6ab50021aea538afcc812e1a0d114c43ab363db911bf071"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">=3.8"
+
 [tool.poetry]
 authors = [
     "Pavel Perestoronin <pavel.perestoronin@kpn.com>",
@@ -17,7 +20,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -31,7 +33,7 @@ requires = ["poetry-core", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
+python = "^3.8.0"
 pydantic = "^1.10.4"
 typing-extensions = "^4.4.0"
 redis = {version = "^4.4.2", optional = true}
@@ -108,9 +110,6 @@ ignore = [
     "PT013",
     "RET505",
     "TRY003",
-    "UP006",  # 3.9
-    "UP007",  # 3.10
-    "UP033",  # 3.9
 ]
 unfixable = ["B"]
 


### PR DESCRIPTION
P.S. Unfortunately, I also had to kill the PyPy 3.8 & 3.9 compatibility, as they don't allow using `Protocol` with `ParamSpec`. This is a PyPy bug, but maintaining this compatibility becomes more and more difficult