### PR TITLE
NEW: add clear method to caches

### DIFF
--- a/cachetory/caches/async_.py
+++ b/cachetory/caches/async_.py
@@ -139,6 +139,10 @@ class Cache(
         """
         return await self._backend.delete(f"{self._prefix}{key}")
 
+    async def clear(self) -> None:
+        """Delete all cache items."""
+        return await self._backend.clear()
+
     async def __aexit__(
         self,
         exc_type: type[BaseException] | None,

--- a/cachetory/caches/sync.py
+++ b/cachetory/caches/sync.py
@@ -138,6 +138,10 @@ class Cache(
         """
         return self._backend.delete(f"{self._prefix}{key}")
 
+    def clear(self) -> None:
+        """Delete all cache items."""
+        return self._backend.clear()
+
     def __delitem__(self, key: str) -> None:
         """
         Delete the cache item.

--- a/tests/caches/test_async.py
+++ b/tests/caches/test_async.py
@@ -47,6 +47,17 @@ async def test_delete(memory_cache: Cache[int, bytes]) -> None:
 
 
 @mark.asyncio
+async def test_clear(memory_cache: Cache[int, bytes]) -> None:
+    await memory_cache.set("foo", 42)
+    await memory_cache.set("bar", 42)
+
+    await memory_cache.clear()
+
+    assert await memory_cache.get("foo") is None
+    assert await memory_cache.get("bar") is None
+
+
+@mark.asyncio
 async def test_serialize_executor() -> None:
     cache = Cache[int, bytes](
         serializer=serializers.from_url("pickle://"),

--- a/tests/caches/test_sync.py
+++ b/tests/caches/test_sync.py
@@ -46,6 +46,16 @@ def test_delete(memory_cache: Cache[int, bytes]) -> None:
     assert memory_cache.get("foo") is None
 
 
+def test_clear_cache(memory_cache: Cache[int, bytes]) -> None:
+    memory_cache.set("foo", 42)
+    memory_cache.set("bar", 42)
+
+    memory_cache.clear()
+
+    assert memory_cache.get("foo") is None
+    assert memory_cache.get("bar") is None
+
+
 def test_del_item(memory_cache: Cache[int, bytes]) -> None:
     memory_cache.set("foo", 42)
     del memory_cache["foo"]


### PR DESCRIPTION
I've manually reviewed the backends and all of them have a well defined `clear()` method, which I saw was tested elsewhere.

closes #135